### PR TITLE
Fix vsce build

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "flatpakvscode",
   "displayName": "Flatpak integration",
   "description": "Flatpak integration",
-  "publisher": "Bilal Elmoussaoui",
+  "publisher": "bilal-elmoussaoui",
   "version": "0.0.1",
   "engines": {
     "vscode": "^1.50.0"


### PR DESCRIPTION
```
[haecker-felix@t580 flatpak-vscode]$ vsce package
 ERROR  Invalid publisher name 'Bilal Elmoussaoui'. Expected the identifier of a publisher, not its human-friendly name.  Learn more: https://code.visualstudio.com/api/working-with-extensions/publishing-extension#publishing-extensions
```