### PR TITLE
make r-a runnables use SDK's cargo

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,7 @@ import { window, ExtensionContext, commands } from 'vscode'
 import { exists, findManifests } from './utils'
 import { promises as fs } from 'fs'
 import { FlatpakTaskTerminal, TaskMode } from './terminal'
+import { restoreRustAnalyzerConfigOverrides } from './integration/rustAnalyzer'
 const { executeCommand, registerCommand } = commands
 const { showInformationMessage } = window
 
@@ -176,10 +177,7 @@ export async function deactivate(): Promise<void> {
   if (manifest) {
     switch (manifest?.sdk()) {
       case 'rust':
-        await manifest.restoreWorkspaceConfig('rust-analyzer',
-          'server.path')
-        await manifest.restoreWorkspaceConfig('rust-analyzer',
-          'files.excludeDirs')
+        await restoreRustAnalyzerConfigOverrides(manifest)
         break
     }
   }

--- a/src/integration/rustAnalyzer.ts
+++ b/src/integration/rustAnalyzer.ts
@@ -1,0 +1,28 @@
+import { FlatpakManifest } from "../terminal"
+
+export const loadRustAnalyzerConfigOverrides = async (manifest: FlatpakManifest): Promise<void> => {
+    await manifest.overrideWorkspaceCommandConfig('rust-analyzer', 'server.path', 'rust-analyzer')
+
+    const buildSystemBuildDir = manifest.buildSystemBuildDir()
+
+    const envArgs = new Map()
+    if (buildSystemBuildDir !== null) {
+        envArgs.set("CARGO_HOME", `${buildSystemBuildDir}/cargo-home`)
+    }
+    await manifest.overrideWorkspaceCommandConfig('rust-analyzer', 'runnables.overrideCargo', 'cargo', envArgs)
+
+    const cargoExtraArgs = []
+    if (buildSystemBuildDir !== null) {
+        cargoExtraArgs.push(`--target-dir=${buildSystemBuildDir}/src`)
+    }
+    await manifest.overrideWorkspaceConfig('rust-analyzer', 'runnables.cargoExtraArgs', cargoExtraArgs)
+
+    await manifest.overrideWorkspaceConfig('rust-analyzer', 'files.excludeDirs', ['.flatpak'])
+}
+
+export const restoreRustAnalyzerConfigOverrides = async (manifest: FlatpakManifest): Promise<void> => {
+    await manifest.restoreWorkspaceConfig('rust-analyzer', 'server.path')
+    await manifest.restoreWorkspaceConfig('rust-analyzer', 'runnables.overrideCargo')
+    await manifest.restoreWorkspaceConfig('rust-analyzer', 'runnables.cargoExtraArgs')
+    await manifest.restoreWorkspaceConfig('rust-analyzer', 'files.excludeDirs')
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -3,6 +3,7 @@ import { promises as fs } from 'fs'
 
 import { Command, FlatpakManifest, TaskMode } from './terminal'
 import { exists, setContext } from './utils'
+import { loadRustAnalyzerConfigOverrides } from './integration/rustAnalyzer'
 
 import { commands } from 'vscode'
 import { EXT_ID } from './extension'
@@ -123,26 +124,8 @@ state
     switch (manifest?.sdk()) {
       case 'rust':
         {
-          manifest
-            .overrideWorkspaceCommandConfig(
-              'rust-analyzer',
-              'server.path',
-              'rust-analyzer'
-            )
-            .then(
-              () => { }, // eslint-disable-line @typescript-eslint/no-empty-function
-              () => { } // eslint-disable-line @typescript-eslint/no-empty-function
-            )
-          manifest
-            .overrideWorkspaceConfig(
-              'rust-analyzer',
-              'files.excludeDirs',
-              ['.flatpak']
-            )
-            .then(
-              () => { }, // eslint-disable-line @typescript-eslint/no-empty-function
-              () => { } // eslint-disable-line @typescript-eslint/no-empty-function
-            )
+          loadRustAnalyzerConfigOverrides(manifest)
+            .then(() => { }, () => { }) // eslint-disable-line @typescript-eslint/no-empty-function
         }
         break
     }


### PR DESCRIPTION
This is to avoid rebuilding when running runnables