### PR TITLE
refactor: create FlatpakManifestFinder

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,11 +1,12 @@
 import * as store from './store'
 import { window, ExtensionContext, commands } from 'vscode'
-import { exists, findManifests, ensureDocumentsPortal } from './utils'
+import { exists, ensureDocumentsPortal } from './utils'
 import { promises as fs } from 'fs'
 import { StatusBarItem } from './statusBarItem'
 import { FlatpakTerminal } from './flatpakTerminal'
 import { TaskMode } from './taskMode'
 import { restoreRustAnalyzerConfigOverrides } from './integration/rustAnalyzer'
+import { FlatpakManifestFinder } from './flatpakManifestFinder'
 const { executeCommand, registerCommand } = commands
 const { showInformationMessage } = window
 
@@ -16,8 +17,9 @@ export async function activate(context: ExtensionContext): Promise<void> {
   statusBarItem = new StatusBarItem(context)
 
   // Look for a flatpak manifest
-  const isSandboxed = await exists('/.flatpak-info')
-  const manifests = await findManifests(isSandboxed)
+  const manifestFinder = new FlatpakManifestFinder()
+  const manifests = await manifestFinder.find()
+
   if (manifests.length > 0) {
     // Make sures the documents portal is running
     await ensureDocumentsPortal()

--- a/src/flatpakManifestFinder.ts
+++ b/src/flatpakManifestFinder.ts
@@ -1,0 +1,73 @@
+import { FlatpakManifest } from './flatpakManifest';
+import { FlatpakManifestSchema } from './flatpak.types'
+import { Uri, workspace } from 'vscode';
+import * as yaml from 'js-yaml'
+import { exists } from './utils';
+
+export class FlatpakManifestFinder {
+    async find(): Promise<FlatpakManifest[]> {
+        const uris: Uri[] = await workspace.findFiles(
+            '**/*.{json,yaml,yml}',
+            '**/{target,.vscode,.flatpak-builder,flatpak_app,.flatpak}/*',
+            1000
+        )
+        const manifests = []
+        for (const uri of uris) {
+            try {
+                const manifest = await this.parseManifest(uri)
+                if (manifest) {
+                    manifests.push(manifest)
+                }
+            } catch (err) {
+                console.warn(`Failed to parse the manifest at ${uri.fsPath}`)
+            }
+        }
+        return manifests
+    }
+
+    private async parseManifest(uri: Uri): Promise<FlatpakManifest | null> {
+        const textDocument = await workspace.openTextDocument(uri)
+        const data = textDocument.getText()
+
+        let manifest = null
+        switch (textDocument.languageId) {
+            case 'json':
+                manifest = JSON.parse(data) as FlatpakManifestSchema
+                break
+            case 'yaml':
+                manifest = yaml.safeLoad(data) as FlatpakManifestSchema
+                break
+            default:
+                // This should not be triggered since only json,yaml,yml are passed in findFiles
+                console.error(`Trying to parse a document with invalid language id: ${textDocument.languageId}`)
+                break
+        }
+
+        if (manifest === null) {
+            return null
+        }
+
+        if (this.isValidManifest(manifest)) {
+            return new FlatpakManifest(
+                uri,
+                manifest,
+                await this.isSandboxed()
+            )
+        }
+
+        return null
+    }
+
+    /**
+     * Checks whether VSCode is installed in a sandbox
+     */
+    private async isSandboxed(): Promise<boolean> {
+        return await exists('/.flatpak-info')
+    }
+
+    private isValidManifest(manifest: FlatpakManifestSchema): boolean {
+        const hasId = (manifest.id || manifest['app-id']) !== undefined
+        const hasModules = manifest.modules !== undefined
+        return hasId && hasModules
+    }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,10 +1,6 @@
 import * as dbus from 'dbus-next'
 import { promises as fs, constants as fsc } from 'fs'
-import * as path from 'path'
-import { commands, window, workspace, Uri } from 'vscode'
-import * as yaml from 'js-yaml'
-import { FlatpakManifestSchema } from './flatpak.types'
-import { FlatpakManifest } from './flatpakManifest'
+import { commands } from 'vscode'
 
 export const ensureDocumentsPortal = async (): Promise<void> => {
   try {
@@ -13,79 +9,9 @@ export const ensureDocumentsPortal = async (): Promise<void> => {
     const portal = obj.getInterface('org.freedesktop.portal.Documents')
     await portal.GetMountPoint()
   } catch (err) {
-    console.log('Failed to ensure documents portal')
-    console.log(err)
+    console.warn('Failed to ensure documents portal')
+    console.warn(err)
   }
-}
-
-export const isFlatpak = (manifest: FlatpakManifestSchema): boolean => {
-  const hasId = (manifest.id || manifest['app-id']) !== undefined
-  const hasModules = manifest.modules !== undefined
-  return hasId && hasModules
-}
-
-export const parseManifest = async (
-  uri: Uri,
-  isSandboxed: boolean
-): Promise<FlatpakManifest | null> => {
-  const data = (await fs.readFile(uri.fsPath)).toString()
-  let manifest = null
-
-  switch (path.extname(uri.fsPath)) {
-    case '.json':
-      manifest = JSON.parse(data) as FlatpakManifestSchema
-      break
-    case '.yml':
-    case '.yaml':
-      manifest = yaml.safeLoad(data) as FlatpakManifestSchema
-      break
-    default:
-      window
-        .showErrorMessage(
-          'Failed to parse the manifest, please use a valid extension.'
-        ).
-        then(
-          () => { }, // eslint-disable-line @typescript-eslint/no-empty-function
-          () => { } // eslint-disable-line @typescript-eslint/no-empty-function
-        )
-      break
-  }
-
-  if (manifest === null) {
-    return null
-  }
-
-  if (isFlatpak(manifest)) {
-    return new FlatpakManifest(
-      uri,
-      manifest,
-      isSandboxed
-    )
-  }
-
-  return null
-}
-
-export const findManifests = async (
-  isSandboxed: boolean
-): Promise<FlatpakManifest[]> => {
-  const uris: Uri[] = await workspace.findFiles(
-    '**/*.{json,yaml,yml}',
-    '**/{target,.vscode,.flatpak-builder,flatpak_app,.flatpak}/*',
-    1000
-  )
-  const manifests = []
-  for (const uri of uris) {
-    try {
-      const manifest = await parseManifest(uri, isSandboxed)
-      if (manifest) {
-        manifests.push(manifest)
-      }
-    } catch (err) {
-      console.warn(`Failed to parse the manifest at ${uri.fsPath}`)
-    }
-  }
-  return manifests
 }
 
 export const setContext = (ctx: string, state: boolean | string): void => {


### PR DESCRIPTION
Removes some clutter in utils.ts and uses vscode fs api where applicable

This also makes adding features to it more confined