### PR TITLE
Improve terminal integration

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -5,7 +5,7 @@ import { findInPath } from './utils'
 export class Command {
     name: string
     cwd?: string
-    arguments: readonly string[]
+    arguments: string[]
     isSandboxed: boolean
 
     constructor(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -66,16 +66,16 @@ export async function activate(context: ExtensionContext): Promise<void> {
 
     context.subscriptions.push(
       registerCommand(`${EXT_ID}.runtime-terminal`, () => {
-        const terminal = window.createTerminal('Flatpak: Runtime Terminal')
-        terminal.sendText(manifest.runtimeTerminal().toString())
+        const command = manifest.runtimeTerminal()
+        const terminal = window.createTerminal('Flatpak: Runtime Terminal', command.name, command.arguments)
         terminal.show()
       })
     )
 
     context.subscriptions.push(
       registerCommand(`${EXT_ID}.build-terminal`, () => {
-        const terminal = window.createTerminal('Flatpak: Build Terminal')
-        terminal.sendText(manifest.buildTerminal().toString())
+        const command = manifest.buildTerminal()
+        const terminal = window.createTerminal('Flatpak: Build Terminal', command.name, command.arguments)
         terminal.show()
       })
     )

--- a/src/flatpakManifest.ts
+++ b/src/flatpakManifest.ts
@@ -452,7 +452,7 @@ export class FlatpakManifest {
             '--allow=devel',
             `--bind-mount=/run/user/${uid}/doc=/run/user/${uid}/doc/by-app/${appId}`,
             ...this.finishArgs(),
-            "--talk-name='org.freedesktop.portal.*'",
+            "--talk-name=org.freedesktop.portal.*",
             '--talk-name=org.a11y.Bus',
         ]
 


### PR DESCRIPTION
Running `exit` on either the Build and Runtime terminal now actually exits the terminal.

Additionally, it won't show the commands that was ran to launch the terminal, which I think is cleaner, and user should not worry about the commands.