### PR TITLE
Make isSandboxed static

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,23 @@
 # Change Log
 
+## [0.0.17]
+
+- New output terminal for less output delay and working terminal colors
+- New status bar item for current build and run status
+- New rust-analyzer integration to run runnables within the sandbox
+- Improved build and runtime terminal integration
+- Trigger documents portal in activate (May still be problematic when other extensions, like-rust-analyzer, startups earlier)
+- Code cleanup
+
 ## [0.0.16]
 
 - Mark dependencies as not build after an update
-- Simplif the usage of the extensions, you can now just run a `Flatpak: build` from the command and it will do everything you need. You can followup with a `Flatpak: run` or a `Flatpak: rebuild the application`
+- Simplify the usage of the extensions, you can now just run a `Flatpak: build` from the command and it will do everything you need. You can followup with a `Flatpak: run` or a `Flatpak: rebuild the application`
 
 ## [0.0.15]
 
 - Don't hardcode the path to `/usr/bin/bash`
-- Code cleanup 
+- Code cleanup
 
 ## [0.0.14]
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     {
       "name": "Julian Hofer",
       "email": "julianhofer@gnome.org"
+    },
+    {
+      "name": "Dave Patrick"
     }
   ],
   "preview": true,

--- a/src/flatpakManifest.ts
+++ b/src/flatpakManifest.ts
@@ -16,12 +16,10 @@ export class FlatpakManifest {
     workspace: string
     stateFile: string // A on disk copy of the pipeline state
     stateDir: string
-    isSandboxed: boolean
 
     constructor(
         uri: vscode.Uri,
         manifest: FlatpakManifestSchema,
-        isSandboxed: boolean
     ) {
         this.uri = uri
         this.manifest = manifest
@@ -30,7 +28,6 @@ export class FlatpakManifest {
         this.repoDir = path.join(this.buildDir, 'repo')
         this.stateDir = path.join(this.buildDir, 'flatpak-builder')
         this.stateFile = path.join(this.buildDir, 'pipeline.json')
-        this.isSandboxed = isSandboxed
     }
 
     id(): string {
@@ -83,7 +80,6 @@ export class FlatpakManifest {
                 `${this.manifest.sdk}//${this.manifest['runtime-version']}`,
             ],
             this.workspace,
-            this.isSandboxed
         )
     }
 
@@ -103,7 +99,6 @@ export class FlatpakManifest {
                 this.manifest['runtime-version'],
             ],
             this.workspace,
-            this.isSandboxed
         )
     }
 
@@ -123,7 +118,6 @@ export class FlatpakManifest {
             'flatpak-builder',
             args,
             this.workspace,
-            this.isSandboxed
         )
     }
 
@@ -145,7 +139,6 @@ export class FlatpakManifest {
             'flatpak-builder',
             args,
             this.workspace,
-            this.isSandboxed
         )
     }
 
@@ -268,7 +261,6 @@ export class FlatpakManifest {
                         configOpts,
                     ],
                     path.join(this.workspace),
-                    this.isSandboxed
                 )
             )
         }
@@ -277,7 +269,6 @@ export class FlatpakManifest {
                 'flatpak',
                 ['build', ...buildArgs, this.repoDir, 'make', '-p', '-n', '-s'],
                 path.join(this.workspace),
-                this.isSandboxed
             )
         )
 
@@ -286,7 +277,6 @@ export class FlatpakManifest {
                 'flatpak',
                 ['build', ...buildArgs, this.repoDir, 'make', 'V=0', `-j${numCPUs}`, 'install'],
                 path.join(this.workspace),
-                this.isSandboxed
             )
         )
         return commands
@@ -317,7 +307,6 @@ export class FlatpakManifest {
                     'mkdir',
                     ['-p', cmakeBuildDir],
                     this.workspace,
-                    this.isSandboxed
                 )
             )
             commands.push(
@@ -338,7 +327,6 @@ export class FlatpakManifest {
                         configOpts,
                     ],
                     path.join(this.workspace, cmakeBuildDir),
-                    this.isSandboxed
                 )
             )
         }
@@ -347,7 +335,6 @@ export class FlatpakManifest {
                 'flatpak',
                 ['build', ...buildArgs, this.repoDir, 'ninja'],
                 path.join(this.workspace, cmakeBuildDir),
-                this.isSandboxed
             )
         )
 
@@ -356,7 +343,6 @@ export class FlatpakManifest {
                 'flatpak',
                 ['build', ...buildArgs, this.repoDir, 'ninja', 'install'],
                 path.join(this.workspace, cmakeBuildDir),
-                this.isSandboxed
             )
         )
         return commands
@@ -395,7 +381,6 @@ export class FlatpakManifest {
                         configOpts,
                     ],
                     this.workspace,
-                    this.isSandboxed
                 )
             )
         }
@@ -404,7 +389,6 @@ export class FlatpakManifest {
                 'flatpak',
                 ['build', ...buildArgs, this.repoDir, 'ninja', '-C', mesonBuildDir],
                 this.workspace,
-                this.isSandboxed
             )
         )
         commands.push(
@@ -420,7 +404,6 @@ export class FlatpakManifest {
                     mesonBuildDir,
                 ],
                 this.workspace,
-                this.isSandboxed
             )
         )
         return commands
@@ -432,7 +415,6 @@ export class FlatpakManifest {
                 'flatpak',
                 ['build', ...buildArgs, this.repoDir, command],
                 this.workspace,
-                this.isSandboxed
             )
         })
     }
@@ -477,7 +459,7 @@ export class FlatpakManifest {
 
         args.push(this.repoDir)
         args.push(shellCommand)
-        return new Command('flatpak', args, this.workspace, this.isSandboxed)
+        return new Command('flatpak', args, this.workspace)
     }
 
     async overrideWorkspaceCommandConfig(
@@ -487,7 +469,7 @@ export class FlatpakManifest {
         additionalEnvVars?: Map<string, string>,
     ): Promise<void> {
         const commandPath = path.join(this.buildDir, `${command}.sh`)
-        await this.runInRepo(command, true, additionalEnvVars).save(commandPath)
+        await this.runInRepo(command, true, additionalEnvVars).saveAsScript(commandPath)
         await this.overrideWorkspaceConfig(section, configName, commandPath)
     }
 

--- a/src/flatpakManifestFinder.ts
+++ b/src/flatpakManifestFinder.ts
@@ -2,7 +2,6 @@ import { FlatpakManifest } from './flatpakManifest';
 import { FlatpakManifestSchema } from './flatpak.types'
 import { Uri, workspace } from 'vscode';
 import * as yaml from 'js-yaml'
-import { exists } from './utils';
 
 export class FlatpakManifestFinder {
     async find(): Promise<FlatpakManifest[]> {
@@ -51,18 +50,10 @@ export class FlatpakManifestFinder {
             return new FlatpakManifest(
                 uri,
                 manifest,
-                await this.isSandboxed()
             )
         }
 
         return null
-    }
-
-    /**
-     * Checks whether VSCode is installed in a sandbox
-     */
-    private async isSandboxed(): Promise<boolean> {
-        return await exists('/.flatpak-info')
     }
 
     private isValidManifest(manifest: FlatpakManifestSchema): boolean {

--- a/src/flatpakRunner.ts
+++ b/src/flatpakRunner.ts
@@ -70,7 +70,7 @@ export class FlatpakRunner {
     }
 
     this.terminal.appendMessage(command.toString())
-    this.currentProcess = command.run()
+    this.currentProcess = command.spawn()
     this.isRunning = true
 
     this.currentProcess.onData((data) => {


### PR DESCRIPTION
This avoids it getting passed in everywhere

This would work since I don't think it is possible for vscode to transition isSandboxed state without at least restarting