### PR TITLE
fix: Don't rely on latestStep to set status on failure

### DIFF
--- a/src/flatpakRunner.ts
+++ b/src/flatpakRunner.ts
@@ -44,7 +44,7 @@ export class FlatpakRunner {
 
   onError(message: string, command: Command): void {
     this.terminal.appendError(message)
-    failure({ command, message })
+    failure({ mode: this.mode, command, message })
     this.failed = true
     this.isRunning = false
   }

--- a/src/store.ts
+++ b/src/store.ts
@@ -101,6 +101,7 @@ export const state = createStore<State>({
 
 // A typical error
 export interface PayloadError {
+  mode?: TaskMode,
   command: Command | null
   message: string | null
 }
@@ -230,8 +231,8 @@ state
     console.log(payload)
 
     let title = 'An error occurred'
-    if (state.pipeline.latestStep !== null) {
-      title = `Failed to run ${state.pipeline.latestStep}`
+    if (payload.mode !== undefined) {
+      title = `Failed to execute ${payload.mode}`
     }
 
     statusBarItem?.setStatus({


### PR DESCRIPTION
the latestStep isn't updated on failure, making it use the last step before failure