### PR TITLE
Indicate which is the currently active manifest on the manifest selector

### DIFF
--- a/src/manifestManager.ts
+++ b/src/manifestManager.ts
@@ -186,9 +186,14 @@ export class ManifestManager implements vscode.Disposable {
     async selectManifest(): Promise<Manifest | null> {
         const quickPickItems: ManifestQuickPickItem[] = []
         const manifests = await this.getManifests()
+        const activeManifest = this.getActiveManifest()
+
         manifests.forEach((manifest) => {
+            const labelPrefix = manifest.uri.fsPath === activeManifest?.uri.fsPath
+                ? '$(pass-filled)' : '$(circle-large-outline)'
+
             quickPickItems.push({
-                label: manifest.id(),
+                label: `${labelPrefix}  ${manifest.id()}`,
                 detail: manifest.uri.fsPath,
                 manifest: manifest,
             })


### PR DESCRIPTION
Rationale is despite of having the statusBarItem, you might not know which one is active especially if two different manifests has same app id in different location

Closes https://github.com/bilelmoussaoui/flatpak-vscode/issues/96