### PR TITLE
Register commands earlier

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,31 +103,31 @@
       "commandPalette": [
         {
           "command": "flatpak-vscode.runtime-terminal",
-          "when": "flatpakManifestFound"
+          "when": "flatpakHasActiveManifest"
         },
         {
           "command": "flatpak-vscode.build-terminal",
-          "when": "flatpakManifestFound && flatpakInitialized"
-        },
-        {
-          "command": "flatpak-vscode.clean",
-          "when": "flatpakManifestFound"
+          "when": "flatpakHasActiveManifest && flatpakInitialized"
         },
         {
           "command": "flatpak-vscode.update-deps",
-          "when": "flatpakInitialized"
-        },
-        {
-          "command": "flatpak-vscode.build",
-          "when": "flatpakManifestFound && !flatpakApplicationBuilt"
-        },
-        {
-          "command": "flatpak-vscode.rebuild",
-          "when": "flatpakApplicationBuilt"
+          "when": "flatpakHasActiveManifest && flatpakInitialized"
         },
         {
           "command": "flatpak-vscode.run",
-          "when": "flatpakApplicationBuilt"
+          "when": "flatpakHasActiveManifest && flatpakApplicationBuilt"
+        },
+        {
+          "command": "flatpak-vscode.rebuild",
+          "when": "flatpakHasActiveManifest && flatpakApplicationBuilt"
+        },
+        {
+          "command": "flatpak-vscode.clean",
+          "when": "flatpakHasActiveManifest"
+        },
+        {
+          "command": "flatpak-vscode.build",
+          "when": "flatpakHasActiveManifest && !flatpakApplicationBuilt"
         }
       ]
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -61,11 +61,6 @@ class Extension {
 
   async activate() {
     await migrateStateToMemento(this.workspaceState)
-    await ensureDocumentsPortal()
-    await this.manifestManager.loadLastActiveManifest()
-
-    console.log(`Flatpak version: ${FLATPAK_VERSION}`)
-    console.log(`is VSCode running in sandbox: ${IS_SANDBOXED.toString()}`)
 
     // Private commands
     this.registerCommand('show-active-manifest', async () => {
@@ -204,6 +199,10 @@ class Extension {
         this.outputTerminal.appendMessage('Nothing to do')
       }
     })
+
+    console.log("All commands are now loaded")
+
+    await this.manifestManager.loadLastActiveManifest()
   }
 
   async deactivate() {
@@ -336,6 +335,11 @@ let extension: Extension
 export async function activate(extCtx: ExtensionContext): Promise<void> {
   // TODO cleaner way to set FLATPAK_VERSION
   FLATPAK_VERSION = execSync((new Command('flatpak', ['--version'])).toString()).toString().trim().replace('Flatpak', '').trim()
+
+  void ensureDocumentsPortal()
+
+  console.log(`Flatpak version: ${FLATPAK_VERSION}`)
+  console.log(`is VSCode running in sandbox: ${IS_SANDBOXED.toString()}`)
 
   extension = new Extension(extCtx)
   await extension.activate()

--- a/src/manifestManager.ts
+++ b/src/manifestManager.ts
@@ -78,7 +78,6 @@ export class ManifestManager implements vscode.Disposable {
 
         this.statusItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left)
         this.updateStatusItem()
-        this.statusItem.show()
     }
 
     async loadLastActiveManifest(): Promise<void> {
@@ -112,6 +111,11 @@ export class ManifestManager implements vscode.Disposable {
     async getManifests(): Promise<ManifestMap> {
         if (this.manifests === undefined) {
             this.manifests = await findManifests()
+
+            this.tryShowStatusItem()
+            this.manifests.onDidItemsChanged(() => {
+                this.tryShowStatusItem()
+            })
         }
 
         return this.manifests
@@ -244,6 +248,12 @@ export class ManifestManager implements vscode.Disposable {
         }
 
         await func(activeManifest)
+    }
+
+    private tryShowStatusItem() {
+        if (this.manifests !== undefined && !this.manifests.isEmpty()) {
+            this.statusItem.show()
+        }
     }
 
     private updateStatusItem() {

--- a/src/manifestMap.ts
+++ b/src/manifestMap.ts
@@ -4,16 +4,26 @@ import * as vscode from 'vscode'
 export class ManifestMap {
     private readonly inner: Map<string, Manifest>
 
+    private readonly _onDidItemsChanged = new vscode.EventEmitter<void>()
+    readonly onDidItemsChanged = this._onDidItemsChanged.event
+
     constructor() {
         this.inner = new Map()
     }
 
     add(manifest: Manifest): void {
         this.inner.set(manifest.uri.fsPath, manifest)
+        this._onDidItemsChanged.fire()
     }
 
     delete(uri: vscode.Uri): boolean {
-        return this.inner.delete(uri.fsPath)
+        const isDeleted = this.inner.delete(uri.fsPath)
+
+        if (isDeleted) {
+            this._onDidItemsChanged.fire()
+        }
+
+        return isDeleted
     }
 
     get(uri: vscode.Uri): Manifest | undefined {

--- a/src/workspaceState.ts
+++ b/src/workspaceState.ts
@@ -24,7 +24,7 @@ export class WorkspaceState {
     }
 
     async setActiveManifestUri(value: vscode.Uri | undefined): Promise<void> {
-        await this.setContext('flatpakManifestFound', value !== undefined)
+        await this.setContext('flatpakHasActiveManifest', value !== undefined)
         await this.update('ActiveManifestUri', value)
     }
 


### PR DESCRIPTION
Fixes #103

We won't now wait for documents portal to open. Since it is still problematic
when rust-analyzer (or other extensions), launches first.

Also, don't show the ManifestManager's status item until there is some manifest
in the manifestMap. This is to avoid it being shown even the extension is
activated despite having no valid FlatpakManifest.

Add a when guard to every command (except show-output-terminal & select-manifest)
to only show when a manifest is active. Commands like rebuild will still be shown
even the last manifest is still deleted before this commit.

Rename too flatpakManifestFound to flatpakHasActiveManifest

Also reorder the menus.commandPalette in the package.json to have the same order
as in contributions.commands.