### PR TITLE
Add 'generatePathOverride' and 'exists' tests

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -50,16 +50,7 @@ export function getHostEnv(): Map<string, string> {
 }
 
 export function generatePathOverride(oldValue: string, prependValues: (PathLike | undefined)[], appendValues: (PathLike | undefined)[]): string {
-    let output = oldValue || ''
-    for (const path of prependValues) {
-        if (path) {
-            output = `${path.toString()}:${output}`
-        }
-    }
-    for (const path of appendValues) {
-        if (path) {
-            output = `${output}:${path.toString()}`
-        }
-    }
-    return output
+    return [...prependValues, oldValue, ...appendValues]
+        .filter((path) => !!path)  // Filters out empty strings and undefined
+        .join(':')
 }


### PR DESCRIPTION
The test failed at `assert.equal('/b/b:/c/c', generatePathOverride('', ['/b/b'], ['/c/c']))`. Not sure if the assertion was wrong

```shell
AssertionError [ERR_ASSERTION]: '/b/b:/c/c' == '/b/b::/c/c'
      + expected - actual

      -/b/b:/c/c
      +/b/b::/c/c
```