### PR TITLE
Don't allow building when there are some errors found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## [Unreleased]
+
+- New play and stop button in editor title UI
+- Build terminal now uses the application ID
+- Runtime terminal now uses the runtime ID
+- Show error if certain runtimes are not installed
+- Improved other extension integration API
+- Fix migration
+
 ## [0.0.23]
 
 - Integrate with Vala language server

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
         },
         {
           "command": "flatpak-vscode.stop",
-          "when": "flatpakRunnerActive"
+          "when": "flatpakHasActiveManifest && flatpakRunnerActive"
         },
         {
           "command": "flatpak-vscode.clean",

--- a/src/command.ts
+++ b/src/command.ts
@@ -2,6 +2,7 @@ import { IS_SANDBOXED } from './extension'
 import * as fs from 'fs/promises'
 import * as pty from './nodePty'
 import { PathLike } from 'fs'
+import { execFileSync } from 'child_process'
 
 export class Command {
     readonly program: string
@@ -43,5 +44,9 @@ export class Command {
         return pty.spawn(this.program, this.args, {
             cwd: this.cwd,
         })
+    }
+
+    execSync(): Buffer {
+        return execFileSync(this.program, this.args)
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,7 +60,7 @@ class Extension {
         this.registerCommand('show-active-manifest', async () => {
             await this.manifestManager.doWithActiveManifest(async (activeManifest) => {
                 await vscode.window.showTextDocument(activeManifest.uri)
-            })
+            }, false)
         })
 
         // Public commands

--- a/src/flatpakUtils.ts
+++ b/src/flatpakUtils.ts
@@ -1,5 +1,25 @@
-import { execSync } from 'child_process'
 import { Command } from './command'
+
+export interface Runtime {
+    id: string
+    version: string
+}
+
+export function getAvailableRuntimes(): Runtime[] {
+    const command = new Command('flatpak', ['list', '--runtime', '--columns=application,branch'])
+    const result = command.execSync().toString()
+
+    const runtimes = []
+    for (const line of result.split(/\r?\n/)) {  // Split at new line
+        const [id, version] = line.split(/\s+/)  // Split at whitespace
+
+        if (id !== undefined && version !== undefined) {
+            runtimes.push({ id, version })
+        }
+    }
+
+    return runtimes
+}
 
 let FLATPAK_VERSION_CACHE: string | undefined
 
@@ -10,7 +30,8 @@ let FLATPAK_VERSION_CACHE: string | undefined
 export function getFlatpakVersion(): string {
     if (FLATPAK_VERSION_CACHE === undefined) {
         const command = new Command('flatpak', ['--version'])
-        FLATPAK_VERSION_CACHE = execSync(command.toString())
+        FLATPAK_VERSION_CACHE = command
+            .execSync()
             .toString()
             .replace('Flatpak', '')
             .trim()

--- a/src/manifestManager.ts
+++ b/src/manifestManager.ts
@@ -236,7 +236,7 @@ export class ManifestManager implements vscode.Disposable {
      * If it doesn't exist. Show manifests picker, or show messages.
      * @param func Callback function where the active manifest can be handled
      */
-    async doWithActiveManifest(func: (manifest: Manifest) => Promise<void> | void): Promise<void> {
+    async doWithActiveManifest(func: (manifest: Manifest) => Promise<void> | void, checkForError = true): Promise<void> {
         let activeManifest = this.getActiveManifest()
 
         if (activeManifest === null) {
@@ -246,6 +246,14 @@ export class ManifestManager implements vscode.Disposable {
                 return
             }
             activeManifest = selectedManifest
+        }
+
+        if (checkForError) {
+            const manifestError = activeManifest.checkForError()
+            if (manifestError !== null) {
+                void vscode.window.showWarningMessage(`Active Flatpak manifest has error: ${manifestError}`)
+                return
+            }
         }
 
         await func(activeManifest)

--- a/src/manifestManager.ts
+++ b/src/manifestManager.ts
@@ -251,7 +251,7 @@ export class ManifestManager implements vscode.Disposable {
         if (checkForError) {
             const manifestError = activeManifest.checkForError()
             if (manifestError !== null) {
-                void vscode.window.showWarningMessage(`Active Flatpak manifest has error: ${manifestError}`)
+                void vscode.window.showWarningMessage(`Active Flatpak manifest has error: ${manifestError.message}`)
                 return
             }
         }
@@ -277,7 +277,7 @@ export class ManifestManager implements vscode.Disposable {
         } else if (manifestError !== null) {
             this.statusItem.text = `$(package)  ${activeManifest.id()}`
             this.statusItem.command = `${EXTENSION_ID}.show-active-manifest`
-            this.statusItem.tooltip = manifestError
+            this.statusItem.tooltip = manifestError.message
             this.statusItem.color = new vscode.ThemeColor('notificationsErrorIcon.foreground')
         } else {
             this.statusItem.text = `$(package)  ${activeManifest.id()}`

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert'
 import { Uri } from 'vscode'
 import { resolve } from 'path'
 import { isValidDbusName, parseManifest } from '../../manifestUtils'
-import { versionCompare } from '../../flatpakVersion'
+import { versionCompare } from '../../flatpakUtils'
 import { exists, generatePathOverride } from '../../utils'
 
 function intoUri(path: string): Uri {
@@ -144,7 +144,7 @@ suite('manifestUtils', () => {
     })
 })
 
-suite('flatpakVersion', () => {
+suite('flatpakUtils', () => {
     test('versionCompare', () => {
         assert(versionCompare('1.12.5', '1.12.0'))
         assert(versionCompare('1.8.5', '1.2.0'))


### PR DESCRIPTION
Closes #78

Part of #1

Regarding checking if the SDK extension is compatible with runtime, I think it is too cumbersome to check that.