### PR TITLE
Rename select-manifest command to Select or change the active manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [Unreleased]
+
+- Added `mesonbuild.mesonbuild` extension integration.
+- Now showing a warning when trying to run a rebuild with initializing a build.
+
 ## [0.0.24]
 
 - New play and stop button in editor title UI

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,47 +2,46 @@
 
 ## Installation
 
-### Flatpaked VSCodium / Visual Studio Code
+### Flatpaked VSCodium/VSCode
 
-1. Install the node14 extension by executing
-```
+1. Install the node14 SDK extension by executing the following:
+```bash
 flatpak install flathub org.freedesktop.Sdk.Extension.node14
 ```
-Note: It will suggest multiple versions. To be sure which one to use, check the manifest in the flathub repo of [VSCodium](https://github.com/flathub/com.vscodium.codium/blob/master/com.vscodium.codium.yaml) / [Visual Studio Code](https://github.com/flathub/com.visualstudio.code/blob/master/com.visualstudio.code.yaml).
+Note: It will suggest multiple versions. To be sure which one to use, check the manifest in the flathub repo of [VSCodium](https://github.com/flathub/com.vscodium.codium/blob/master/com.vscodium.codium.yaml)/[VSCode](https://github.com/flathub/com.visualstudio.code/blob/master/com.visualstudio.code.yaml).
 
-2. Enable it by adding the following line to ~/.bash_profile
-```
+2. Enable it by adding the following line to `~/.bash_profile`:
+```bash
 export FLATPAK_ENABLE_SDK_EXT=node14
 ```
 
-3. Log out and in again
+3. Log out and in again.
 
-4. Open the `flatpak-vscode` repo with your editor
+4. Open the `flatpak-vscode` repository with your editor.
 
-5. Within the integrated terminal of your editor, execute at the root of the repository
-```
+5. Within the integrated terminal of your editor, execute the following commands at the root of the repository:
+```bash
 npm install --global yarn
 yarn install
 ```
 
-6. To start debugging, run `F5`
+6. To start debugging, run `F5`.
 
-### Directly installed VSCodium / Visual Studio Code
+### Directly installed VSCodium/VSCode
 
-1. Install `yarn` with your preferred method and make sure it is in your PATH
+1. Install `yarn` with your preferred method and make sure it is in your `PATH`.
 
-2. Execute at the root of the repository
-```
+2. Execute the following at the root of the repository:
+```bash
 yarn install
 ```
 
-3. To start debugging, run `F5`
+3. To start debugging, run `F5`.
 
 
 ## Integration with other extensions
 
-Other extensions like `rust-analyzer` and `vala` works better mostly if it is integrated with the
-Flatpak runtime. To add an integration, follow the following steps:
+To add an integration, follow the following steps:
 
 1. Create a new file in `src/integration/`.
 2. Create a new class in the created file that extends the `Integration` abstract class from `src/integration/base.ts`. It has the following abstract methods:

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# VSCode + Flatpak integration
+# VSCode + Flatpak Integration
 
 ![CI](https://github.com/bilelmoussaoui/flatpak-vscode/workflows/CI/badge.svg) ![Visual Studio Marketplace Installs](https://img.shields.io/visual-studio-marketplace/i/bilelmoussaoui.flatpak-vscode)
 [![Matrix Chat](https://img.shields.io/badge/Matrix-Chat-green)](https://matrix.to/#/#flatpak-vscode:gnome.org)
 
-A very simple VSCode extension that detects a Flatpak manifest and offers various commands to build, run & export a bundle.
+A simple VSCode extension that detects a Flatpak manifest and offers various commands to build, run, and export a bundle.
 
 ## Download
 
@@ -15,20 +15,20 @@ A very simple VSCode extension that detects a Flatpak manifest and offers variou
 - `flatpak`
 - `flatpak-builder`
 
-  if you're using Fedora Silverblue, you will have to layer `flatpak-builder` as it is no longer part of the base image. You can use something like `rpm-ostree install flatpak-builder`
+  If you're using Fedora Silverblue, you will have to layer `flatpak-builder` as it is no longer part of the base image. You can use something like `rpm-ostree install flatpak-builder`.
 
 ## Commands
 
 - Build: Initialize a Flatpak build, update the dependencies & build them. It also does a first build of the application.
 - Rebuild: Rebuild the application and triggers a "Run" command.
 - Stop: Stop the currently running task.
-- Run: Run the application
+- Run: Run the application.
 - Update Dependencies: Download/Update the dependencies and builds them.
 - Clean: Clean the Flatpak repo directory (`.flatpak/repo`) inside the current workspace.
 - Runtime Terminal: Spawn a new terminal inside the specified SDK.
 - Build Terminal: Spawn a new terminal inside the current build repository (Note that the SDKs used are automatically mounted and enabled as well).
 - Show Output Terminal: Show the output terminal of the build and run commands.
-- Select Manifest: Change the active manifest.
+- Select Manifest: Select or change the active manifest.
 
 ## Integrations
 
@@ -44,13 +44,13 @@ the host. If you want to contribute on adding an integration, see [CONTRIBUTING]
 
 ### [Rust Analyzer](https://marketplace.visualstudio.com/items?itemName=matklad.rust-analyzer)
 
-- Overrides `rust-analyzer.server.path` to use the SDK's rust-analyzer and `rust-analyzer.runnables.overrideCargo` to use the SDK's cargo. This make sures that rust-analyzer and cargo uses package from the runtime instead of the host packages.
-- Overrides `rust-analyzer.runnables.cargoExtraArgs` to set cargo's `--target-dir` to `_build/src`. Identical target dir must be set on your build system to prevent rebuilding when running rust-analyzer runnables.
+- Overrides `rust-analyzer.server.path` and `rust-analyzer.runnables.overrideCargo` to use the SDK's rust-analyzer and cargo binaries respectively. This is to avoid requiring build dependencies to be installed in the host.
+- Overrides `rust-analyzer.runnables.cargoExtraArgs` to set cargo's `--target-dir` to `_build/src`. Identical target directory must be set on your build system to prevent rebuilding when running rust-analyzer runnables.
 - Overrides `rust-analyzer.files.excludeDirs` to set rust-analyzer to ignore `.flatpak` folder.
 
 ### [Vala](https://marketplace.visualstudio.com/items?itemName=prince781.vala)
 
-- Overrides `vls.languageServerPath` to use the SDK's vls.
+- Overrides `vls.languageServerPath` to use the SDK's Vala Language Server.
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "commands": [
       {
         "command": "flatpak-vscode.select-manifest",
-        "title": "Change active manifest",
+        "title": "Select or change the active manifest",
         "category": "Flatpak"
       },
       {


### PR DESCRIPTION
So we can use `select manifest` as a search keyword in the command palette

Also improve documentations a bit