### PR TITLE
Build pipeline refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ## [Unreleased]
 
 - Added `mesonbuild.mesonbuild` extension integration.
-- Now showing a warning when trying to run a rebuild with initializing a build.
-- Support `post-install`
+- Added `post-install` manifest option support.
+- Rename `rebuild` command to `build-and-run`. It would also now do a build automatically without having to run a separate `build` command.
+- Don't require for the build to be initialized when running `clean` command.
 
 ## [0.0.24]
 

--- a/package.json
+++ b/package.json
@@ -46,8 +46,6 @@
     "Other"
   ],
   "activationEvents": [
-    "onCommand:flatpak-vscode.build-init",
-    "onCommand:flatpak-vscode.run",
     "workspaceContains:**/*.{json,yaml,yml}"
   ],
   "main": "./out/extension.js",
@@ -84,8 +82,8 @@
         "category": "Flatpak"
       },
       {
-        "command": "flatpak-vscode.rebuild",
-        "title": "Rebuild the application",
+        "command": "flatpak-vscode.build-and-run",
+        "title": "Rebuild and run the application",
         "icon": "$(play)",
         "category": "Flatpak"
       },
@@ -125,7 +123,7 @@
           "when": "flatpakHasActiveManifest && flatpakApplicationBuilt && !flatpakRunnerActive"
         },
         {
-          "command": "flatpak-vscode.rebuild",
+          "command": "flatpak-vscode.build-and-run",
           "when": "flatpakHasActiveManifest && flatpakApplicationBuilt && !flatpakRunnerActive"
         },
         {
@@ -143,7 +141,7 @@
       ],
       "editor/title/run": [
         {
-          "command": "flatpak-vscode.rebuild",
+          "command": "flatpak-vscode.build-and-run",
           "when": "!flatpakRunnerActive"
         },
         {
@@ -154,7 +152,7 @@
     },
     "keybindings": [
       {
-        "command": "flatpak-vscode.rebuild",
+        "command": "flatpak-vscode.build-and-run",
         "linux": "ctrl+alt+B",
         "when": "!flatpakRunnerActive"
       },

--- a/src/buildPipeline.ts
+++ b/src/buildPipeline.ts
@@ -1,0 +1,249 @@
+import { ManifestManager } from './manifestManager'
+import { WorkspaceState } from './workspaceState'
+import { FinishedTask, Runner } from './runner'
+import { TaskMode } from './taskMode'
+import { OutputTerminal } from './outputTerminal'
+import { loadIntegrations } from './integration'
+import * as vscode from 'vscode'
+
+export class BuildPipeline implements vscode.Disposable {
+    private readonly workspaceState: WorkspaceState
+    private readonly manifestManager: ManifestManager
+    private readonly runner: Runner
+    private readonly outputTerminal: OutputTerminal
+
+    constructor(workspaceState: WorkspaceState, manifestManager: ManifestManager) {
+        this.workspaceState = workspaceState
+
+        this.outputTerminal = new OutputTerminal()
+        this.runner = new Runner(this.outputTerminal)
+        this.runner.onDidFinishedTask(async (finishedTask) => {
+            await this.handleFinishedTask(finishedTask)
+        })
+
+        this.manifestManager = manifestManager
+        this.manifestManager.onDidRequestRebuild(async (manifest) => {
+            if (manifest === this.manifestManager.getActiveManifest()) {
+                console.log(`Manifest at ${manifest.uri.fsPath} requested a rebuild`)
+                await this.clean()
+            }
+        })
+    }
+
+    async showOutputTerminal(preserveFocus?: boolean) {
+        await this.outputTerminal.show(preserveFocus)
+    }
+
+    /**
+     * Init the build environment
+     */
+    async initializeBuild(completeBuild = false) {
+        this.runner.completeBuild = completeBuild
+
+        if (this.workspaceState.getInitialized()) {
+            console.log('Skipped build initialization. Already initialized.')
+            return
+        }
+
+        await this.manifestManager.doWithActiveManifest(async (activeManifest) => {
+            await this.outputTerminal.show(true)
+            await this.runner.setCommands([activeManifest.initBuild()], TaskMode.buildInit)
+        })
+    }
+
+    /**
+     * Update the application's dependencies
+     */
+    async updateDependencies(completeBuild = false) {
+        this.runner.completeBuild = completeBuild
+
+        if (!this.workspaceState.getInitialized()) {
+            console.log('Did not run updateDependencies. Build is not initialized.')
+            return
+        }
+
+        await this.manifestManager.doWithActiveManifest(async (activeManifest) => {
+            await this.outputTerminal.show(true)
+            await this.runner.setCommands([activeManifest.updateDependencies()], TaskMode.updateDeps)
+        })
+    }
+
+    /**
+     * Build the application's dependencies
+     */
+    async buildDependencies(completeBuild = false) {
+        this.runner.completeBuild = completeBuild
+
+        if (this.workspaceState.getDependenciesBuilt()) {
+            console.log('Skipped buildDependencies. Depencies are already built.')
+            return
+        }
+
+        await this.manifestManager.doWithActiveManifest(async (activeManifest) => {
+            await this.outputTerminal.show(true)
+            await this.runner.setCommands(
+                [activeManifest.buildDependencies()],
+                TaskMode.buildDeps
+            )
+        })
+    }
+
+    async buildApplication() {
+        if (!this.workspaceState.getDependenciesBuilt()) {
+            console.log('Cannot build application; dependencies are not built.')
+            return
+        }
+
+        await this.manifestManager.doWithActiveManifest(async (activeManifest) => {
+            await this.outputTerminal.show(true)
+            await this.runner.setCommands(activeManifest.build(false), TaskMode.buildApp)
+        })
+    }
+
+    /**
+     * A helper method to chain up commands based on current pipeline state
+     */
+    async build() {
+        this.runner.completeBuild = true
+
+        if (!this.workspaceState.getInitialized()) {
+            await this.initializeBuild()
+        } else if (!this.workspaceState.getDependenciesUpdated()) {
+            await this.updateDependencies()
+        } else if (!this.workspaceState.getDependenciesBuilt()) {
+            await this.buildDependencies()
+        } else if (!this.workspaceState.getApplicationBuilt()) {
+            await this.buildApplication()
+        } else {
+            this.outputTerminal.appendMessage('Nothing to do')
+        }
+    }
+
+    /**
+     *
+     * Rebuild the application
+     * If a buildsystem is set on the latest module, the build/rebuild commands
+     * could be different, the rebuild also triggers a run command afterwards
+     */
+    async rebuild() {
+        if (!this.workspaceState.getApplicationBuilt()) {
+            console.log('Skipped rebuild and run. The application was not built.')
+            void vscode.window.showWarningMessage('Please run a Flatpak build command first.')
+            return
+        }
+
+        await this.manifestManager.doWithActiveManifest(async (activeManifest) => {
+            await this.outputTerminal.show(true)
+            await this.runner.setCommands(activeManifest.build(true), TaskMode.rebuild)
+        })
+    }
+
+    /**
+     * Run the application
+     */
+    async run() {
+        if (!this.workspaceState.getApplicationBuilt()) {
+            console.log('Skipped run; the application is not built.')
+            return
+        }
+
+        await this.manifestManager.doWithActiveManifest(async (activeManifest) => {
+            await this.outputTerminal.show(true)
+            await this.runner.setCommands([activeManifest.run()], TaskMode.run)
+        })
+    }
+
+    /**
+     * Clean build environment
+     */
+    async clean() {
+        if (!this.workspaceState.getInitialized()) {
+            console.log('Skipped clean. Nothing to clean; build is not initialized.')
+            return
+        }
+
+        await this.manifestManager.doWithActiveManifest(async (activeManifest) => {
+            await this.outputTerminal.show(true)
+            await activeManifest.deleteRepoDir()
+            await this.resetState()
+            await this.initializeBuild()
+        })
+    }
+
+    /**
+     * Clear and stop the running commands in the runner
+     */
+    async stop() {
+        await this.outputTerminal.show(true)
+        this.runner.close()
+    }
+
+    async resetState() {
+        await this.workspaceState.setInitialized(false)
+        await this.workspaceState.setDependenciesUpdated(false)
+        await this.workspaceState.setDependenciesBuilt(false)
+        await this.workspaceState.setApplicationBuilt(false)
+    }
+
+    /**
+     * Trigger finished task to update context
+     */
+    async ensureState() {
+        if (this.workspaceState.getInitialized()) {
+            await this.handleFinishedTask({ mode: TaskMode.buildInit, restore: true, completeBuild: false })
+        }
+        if (this.workspaceState.getDependenciesUpdated()) {
+            await this.handleFinishedTask({ mode: TaskMode.updateDeps, restore: true, completeBuild: false })
+        }
+        if (this.workspaceState.getDependenciesBuilt()) {
+            await this.handleFinishedTask({ mode: TaskMode.buildDeps, restore: true, completeBuild: false })
+        }
+        if (this.workspaceState.getApplicationBuilt()) {
+            await this.handleFinishedTask({ mode: TaskMode.buildApp, restore: true, completeBuild: false })
+        }
+    }
+
+    dispose() {
+        this.outputTerminal.dispose()
+        this.runner.dispose()
+    }
+
+    private async handleFinishedTask(finishedTask: FinishedTask) {
+        switch (finishedTask.mode) {
+            case TaskMode.buildInit: {
+                await this.workspaceState.setInitialized(true)
+                const activeManifest = this.manifestManager.getActiveManifest()
+                if (activeManifest) {
+                    await loadIntegrations(activeManifest)
+                }
+                if (!finishedTask.restore) {
+                    await this.updateDependencies()
+                }
+                break
+            }
+            case TaskMode.updateDeps:
+                await this.workspaceState.setDependenciesUpdated(true)
+                // Assume user might want to rebuild dependencies
+                await this.workspaceState.setDependenciesBuilt(false)
+                if (!finishedTask.restore) {
+                    await this.buildDependencies(finishedTask.completeBuild)
+                }
+                break
+            case TaskMode.buildDeps:
+                await this.workspaceState.setDependenciesBuilt(true)
+                if (!finishedTask.restore && finishedTask.completeBuild) {
+                    await this.buildApplication()
+                }
+                break
+            case TaskMode.buildApp:
+                await this.workspaceState.setApplicationBuilt(true)
+                break
+            case TaskMode.rebuild:
+                await this.workspaceState.setApplicationBuilt(true)
+                if (!finishedTask.restore) {
+                    await this.run()
+                }
+                break
+        }
+    }
+}

--- a/src/buildPipeline.ts
+++ b/src/buildPipeline.ts
@@ -231,9 +231,6 @@ export class BuildPipeline implements vscode.Disposable {
                 break
             case TaskMode.rebuild:
                 await this.workspaceState.setApplicationBuilt(true)
-                if (!finishedTask.restore) {
-                    await this.run()
-                }
                 break
         }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -72,24 +72,18 @@ class Extension {
             await this.buildPipeline.showOutputTerminal()
         })
 
-        this.registerCommand(TaskMode.buildInit, async () => {
-            await this.buildPipeline.initializeBuild()
-        })
-
         this.registerCommand(TaskMode.updateDeps, async () => {
             await this.buildPipeline.updateDependencies()
         })
 
-        this.registerCommand(TaskMode.buildDeps, async () => {
-            await this.buildPipeline.buildDependencies()
-        })
+        this.registerCommand('build-and-run', async () => {
+            if (this.workspaceState.getApplicationBuilt()) {
+                await this.buildPipeline.rebuildApplication()
+            } else {
+                await this.buildPipeline.build()
+            }
 
-        this.registerCommand(TaskMode.buildApp, async () => {
-            await this.buildPipeline.buildApplication()
-        })
-
-        this.registerCommand(TaskMode.rebuild, async () => {
-            await this.buildPipeline.rebuild()
+            await this.buildPipeline.run()
         })
 
         this.registerCommand(TaskMode.stop, async () => {
@@ -100,7 +94,6 @@ class Extension {
             await this.buildPipeline.clean()
         })
 
-        // Run the application, only if it was already built
         this.registerCommand(TaskMode.run, async () => {
             await this.buildPipeline.run()
         })

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -37,10 +37,12 @@ export class Runner implements vscode.Disposable {
     close(): void {
         this.terminal.appendMessage('Child process exited')
 
-        this.currentProcess?.kill()
-        this.currentProcess = undefined
         this.commands = []
         this.currentCommand = 0
+
+        this.currentProcess?.kill()
+        this.currentProcess = undefined
+
         this.failed = false
         this.isRunning = false
     }


### PR DESCRIPTION
Closes #63

* Decouple pipeline logic from `extension.ts`
* Removed the message that was added due to #134
* Introduce `build-and-run` command, and remove `rebuild` command
* Don't require for the build to be initialized when running `clean` command
* Remove unnecessary registered commands
* Remove run in `activationEvents` as it won't be visible on command palette until there's an active manifest

Some of #73 still persists though, but I think that's out of scope of the PR

I think the runner should handle commands in an asynchronous synchronous way (`Command.spawn` will be async instead of callbacks, and probably await each command after another instead of having a command queue that `spawnNext` after callback) (Also out of scope of the PR)