### PR TITLE
Don't show run/stop button when there is no active manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,11 +150,11 @@
       "editor/title/run": [
         {
           "command": "flatpak-vscode.build-and-run",
-          "when": "!flatpakRunnerActive"
+          "when": "flatpakHasActiveManifest && !flatpakRunnerActive"
         },
         {
           "command": "flatpak-vscode.stop",
-          "when": "flatpakRunnerActive"
+          "when": "flatpakHasActiveManifest && flatpakRunnerActive"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -162,17 +162,17 @@
       {
         "command": "flatpak-vscode.build-and-run",
         "linux": "ctrl+alt+B",
-        "when": "!flatpakRunnerActive"
+        "when": "flatpakHasActiveManifest && !flatpakRunnerActive"
       },
       {
         "command": "flatpak-vscode.stop",
         "linux": "ctrl+alt+B",
-        "when": "flatpakRunnerActive"
+        "when": "flatpakHasActiveManifest && flatpakRunnerActive"
       },
       {
         "command": "flatpak-vscode.run",
         "linux": "ctrl+alt+R",
-        "when": "!flatpakRunnerActive"
+        "when": "flatpakHasActiveManifest && !flatpakRunnerActive"
       }
     ],
     "terminal": {


### PR DESCRIPTION
Not sure if we want the same with keyboard shortcuts