### PR TITLE
Don't skip removing missingSdkExtensions

### DIFF
--- a/src/manifestUtils.ts
+++ b/src/manifestUtils.ts
@@ -158,8 +158,9 @@ export function checkForMissingRuntimes(manifest: Manifest): string[] {
 
     for (const availableRuntime of getAvailableRuntimes()) {
         if (runtimeVersion === availableRuntime.version) {
-            missingRuntimes.delete(availableRuntime.id)
-            continue
+            if (missingRuntimes.delete(availableRuntime.id)) {
+                continue
+            }
         }
 
         // TODO also check the version


### PR DESCRIPTION
Currently found sdk-extensions aren't removed from
the `missingSdkExtensions` set if the sdk version
matches the runtime version. This happens
for example when using the
org.freedesktop.Platform/Sdk.