### PR TITLE
Dont store initialize state in workspaceState

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,11 +116,11 @@
         },
         {
           "command": "flatpak-vscode.build-terminal",
-          "when": "flatpakHasActiveManifest && flatpakInitialized"
+          "when": "flatpakHasActiveManifest"
         },
         {
           "command": "flatpak-vscode.update-deps",
-          "when": "flatpakHasActiveManifest && flatpakInitialized"
+          "when": "flatpakHasActiveManifest"
         },
         {
           "command": "flatpak-vscode.run",

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -39,6 +39,27 @@ export class Manifest {
         })?.[1]
     }
 
+    async isBuildInitialized(): Promise<boolean> {
+        const repoDir = vscode.Uri.file(this.repoDir)
+        const metadataFile = vscode.Uri.joinPath(repoDir, 'metadata')
+        const filesDir = vscode.Uri.joinPath(repoDir, 'files')
+        const varDir = vscode.Uri.joinPath(repoDir, 'var')
+
+        try {
+            // From gnome-builder
+            // https://gitlab.gnome.org/GNOME/gnome-builder/-/blob/8579055f5047a0af5462e8a587b0742014d71d64/src/plugins/flatpak/gbp-flatpak-pipeline-addin.c#L220
+            return (await vscode.workspace.fs.stat(metadataFile)).type === vscode.FileType.File
+                && (await vscode.workspace.fs.stat(filesDir)).type === vscode.FileType.Directory
+                && (await vscode.workspace.fs.stat(varDir)).type === vscode.FileType.Directory
+        } catch (err) {
+            if (err instanceof vscode.FileSystemError && err.code === 'FileNotFound') {
+                return false
+            }
+
+            throw err
+        }
+    }
+
     /**
      * Check for invalidity in the manifest
      * @returns an Error with a message if there is an error otherwise null

--- a/src/migration.ts
+++ b/src/migration.ts
@@ -52,7 +52,6 @@ export async function migrateStateToMemento(workspaceState: WorkspaceState): Pro
         }
 
         await workspaceState.setActiveManifestUri(vscode.Uri.file(legacyState.selectedManifest.uri.path))
-        await workspaceState.setInitialized(legacyState.pipeline.initialized)
         await workspaceState.setDependenciesUpdated(legacyState.pipeline.dependencies.updated)
         await workspaceState.setDependenciesBuilt(legacyState.pipeline.dependencies.built)
         await workspaceState.setApplicationBuilt(legacyState.pipeline.application.built)

--- a/src/workspaceState.ts
+++ b/src/workspaceState.ts
@@ -4,8 +4,6 @@ type WorkspaceStateKey =
     // The current manifest URI that directs to active manifest.
     // This is used to retrieve the last active manifest between startup.
     'ActiveManifestUri' |
-    // Whether the '.flatpak' directory is present and populated
-    'Initialized' |
     // Whether dependencies of the application are up to date
     'DependenciesUpdated' |
     // Whether dependencies of the application are built
@@ -26,7 +24,6 @@ export class WorkspaceState {
     async loadContexts(): Promise<void> {
         // Contexts has to be set again between startups
         await this.setContext('flatpakHasActiveManifest', this.getActiveManifestUri() !== undefined)
-        await this.setContext('flatpakInitialized', this.getInitialized())
         await this.setContext('flatpakDependenciesBuilt', this.getDependenciesBuilt())
         await this.setContext('flatpakApplicationBuilt', this.getApplicationBuilt())
     }
@@ -38,15 +35,6 @@ export class WorkspaceState {
 
     getActiveManifestUri(): vscode.Uri | undefined {
         return this.get('ActiveManifestUri')
-    }
-
-    async setInitialized(value: boolean): Promise<void> {
-        await this.setContext('flatpakInitialized', value)
-        await this.update('Initialized', value)
-    }
-
-    getInitialized(): boolean {
-        return this.get('Initialized') || false
     }
 
     async setDependenciesUpdated(value: boolean): Promise<void> {


### PR DESCRIPTION
This prevents cases where the user manually deletes .flatpak, but the workspaceState is not updated.
Thus, the only way to correct state is to manually run build init or run clean command.

This fixes that by checking if the build is initialized (same way as gnome-builder) everytime.