### PR TITLE
Rename vls configs to vala

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ the host. If you want to contribute on adding an integration, see [CONTRIBUTING]
 
 ### [Vala](https://marketplace.visualstudio.com/items?itemName=prince781.vala)
 
-- Overrides `vls.languageServerPath` to use the SDK's Vala Language Server.
+- Overrides `vala.languageServerPath` to use the SDK's Vala Language Server.
 
 ## Contributing
 

--- a/src/integration/vala.ts
+++ b/src/integration/vala.ts
@@ -7,10 +7,10 @@ export class Vala extends SdkIntegration {
     }
 
     async load(manifest: Manifest): Promise<void> {
-        await manifest.overrideWorkspaceCommandConfig('vls', 'languageServerPath', 'vala-language-server', '/usr/lib/sdk/vala/bin/')
+        await manifest.overrideWorkspaceCommandConfig('vala', 'languageServerPath', 'vala-language-server', '/usr/lib/sdk/vala/bin/')
     }
 
     async unload(manifest: Manifest): Promise<void> {
-        await manifest.restoreWorkspaceConfig('vls', 'languageServerPath')
+        await manifest.restoreWorkspaceConfig('vala', 'languageServerPath')
     }
 }


### PR DESCRIPTION
Seems to be renamed since https://github.com/vala-lang/vala-vscode/commit/78aa0eb4215a839b2e71c454aae30091ffadc5a4

It silently fails for me when this happened. Would be great to handle this and show error in the UI in the future.