### PR TITLE
docs: Recommend node18

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 16.x
       - name: Publish
         run: |
           yarn install --dev

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x, 16.x, 18.x]
     steps:
       - uses: actions/checkout@v2
       - name: Tests with Node.js ${{ matrix.node-version }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,15 +4,15 @@
 
 ### Flatpaked VSCodium/VSCode
 
-1. Install the node14 SDK extension by executing the following:
+1. Install the node18 SDK extension by executing the following:
 ```bash
-flatpak install flathub org.freedesktop.Sdk.Extension.node14
+flatpak install flathub org.freedesktop.Sdk.Extension.node18
 ```
 Note: It will suggest multiple versions. To be sure which one to use, check the manifest in the flathub repo of [VSCodium](https://github.com/flathub/com.vscodium.codium/blob/master/com.vscodium.codium.yaml)/[VSCode](https://github.com/flathub/com.visualstudio.code/blob/master/com.visualstudio.code.yaml).
 
 2. Enable it by adding the following line to `~/.bash_profile`:
 ```bash
-export FLATPAK_ENABLE_SDK_EXT=node14
+export FLATPAK_ENABLE_SDK_EXT=node18
 ```
 
 3. Log out and in again.
@@ -21,7 +21,6 @@ export FLATPAK_ENABLE_SDK_EXT=node14
 
 5. Within the integrated terminal of your editor, execute the following commands at the root of the repository:
 ```bash
-npm install --global yarn
 yarn install
 ```
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1598,9 +1598,9 @@ minimatch@^3.0.3, minimatch@^3.0.4:
     brace-expansion "^1.1.7"
 
 minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity "sha1-hjelt1nqDW6YcCz7OpKDMjyTr0Q= sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
 
 minipass@^3.0.0:
   version "3.1.6"


### PR DESCRIPTION
Also, remove unneeded yarn installation as it is included in the SDK