### PR TITLE
integration/rustAnalyzer: Don't override target-dir in runnables.extraArgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ the host. If you want to contribute on adding an integration, see [CONTRIBUTING]
 ### [Rust Analyzer](https://marketplace.visualstudio.com/items?itemName=matklad.rust-analyzer)
 
 - Overrides `rust-analyzer.server.path` and `rust-analyzer.runnables.command` to use the SDK's rust-analyzer and cargo binaries respectively. This is to avoid requiring build dependencies to be installed in the host.
-- Overrides `rust-analyzer.runnables.extraArgs` to set cargo's `--target-dir` to `_build/src`. Identical target directory must be set on your build system to prevent rebuilding when running rust-analyzer runnables.
 - Overrides `rust-analyzer.files.excludeDirs` to set rust-analyzer to ignore `.flatpak` folder.
 
 ### [Vala](https://marketplace.visualstudio.com/items?itemName=prince781.vala)

--- a/src/integration/rustAnalyzer.ts
+++ b/src/integration/rustAnalyzer.ts
@@ -13,9 +13,6 @@ export class RustAnalyzer extends SdkIntegration {
         if (buildSystemBuildDir !== null) {
             const envArgs = new Map([['CARGO_HOME', `${buildSystemBuildDir}/cargo-home`]])
             await manifest.overrideWorkspaceCommandConfig('rust-analyzer', 'runnables.command', 'cargo', '/usr/lib/sdk/rust-stable/bin/', envArgs)
-
-            const cargoExtraArgs = [`--target-dir=${buildSystemBuildDir}/src`]
-            await manifest.overrideWorkspaceConfig('rust-analyzer', 'runnables.extraArgs', cargoExtraArgs)
         }
 
         await manifest.overrideWorkspaceConfig('rust-analyzer', 'files.excludeDirs', ['.flatpak'])
@@ -24,7 +21,6 @@ export class RustAnalyzer extends SdkIntegration {
     async unload(manifest: Manifest): Promise<void> {
         await manifest.restoreWorkspaceConfig('rust-analyzer', 'server.path')
         await manifest.restoreWorkspaceConfig('rust-analyzer', 'runnables.command')
-        await manifest.restoreWorkspaceConfig('rust-analyzer', 'runnables.extraArgs')
         await manifest.restoreWorkspaceConfig('rust-analyzer', 'files.excludeDirs')
     }
 }


### PR DESCRIPTION
It was hacky, hardcoded, and may cause repetitive rebuilds on certain cases