### PR TITLE
Revert "Use  instead of absolute path in workspace config"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Add command to show application's data directory
 - Fallback to the Flatpak-installed `flatpak-builder` (`org.flatpak.Builder`) when it is not found on host
-- Use ${workspaceFolder} instead of using absolute path in overridden workspace config command paths
 - Automatically resize output terminal when terminal window resizes
 - Drop rust-analyzer runnables.extraArgs target-dir override
 - Update to node v16

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -616,10 +616,9 @@ export class Manifest {
         binaryPath?: string,
         additionalEnvVars?: Map<string, string>,
     ): Promise<void> {
-        const commandPathSettingsValue = '${workspaceFolder}' + `/.flatpak/${program}.sh`
         const commandPath = path.join(this.buildDir, `${program}.sh`)
         await this.runInRepo(`${binaryPath || ''}${program}`, true, additionalEnvVars).saveAsScript(commandPath)
-        await this.overrideWorkspaceConfig(section, configName, commandPathSettingsValue)
+        await this.overrideWorkspaceConfig(section, configName, commandPath)
     }
 
     async overrideWorkspaceConfig(


### PR DESCRIPTION
Rust analyzer doesn't seem to like it, since it does not expand it to the full path :(