### PR TITLE
manifest: Don't add apostrophe to finish-args ended with asterisk

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -150,13 +150,6 @@ export class Manifest {
                 // --require-version is not supported by flatpak-builder, so filter it out
                 return !['--metadata', '--require-version'].includes(arg.split('=')[0])
             })
-            .map((arg) => {
-                if (arg.endsWith('*')) {
-                    const [key, value] = arg.split('=')
-                    return `${key}='${value}'`
-                }
-                return arg
-            })
     }
 
     runtimeTerminal(): vscode.TerminalOptions {


### PR DESCRIPTION
Probably this was added to avoid shell expansion?

But anyway, you're adding `org.freedesktop.portal.*` without apostrophes: https://github.com/bilelmoussaoui/flatpak-vscode/blob/7f375e0be94d0718e6005a4ecfd69e38bc6f7da9/src/manifest.ts#L577

So I guess is fine to remove it since it's causing issues.

Closes  #198.