### PR TITLE
fix: `TypeError` in podman development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [0.0.33]
+- fix: `TypeError` in podman development
+
 ## [0.0.32]
 
 - Mount fonts directories

--- a/src/nodePty.ts
+++ b/src/nodePty.ts
@@ -1,7 +1,12 @@
-// See https://github.com/microsoft/vscode/issues/84439 why this was needed
+// See also:
+// https://github.com/microsoft/vscode/issues/84439
+// https://code.visualstudio.com/api/advanced-topics/remote-extensions#persisting-secrets
 // TODO: Replace with more reliable way to import node-pty
 
 import * as vscode from 'vscode'
+
+declare const WEBPACK_REQUIRE: typeof require
+declare const NON_WEBPACK_REQUIRE: typeof require
 
 const pty = getCoreNodeModule('node-pty') as typeof import('node-pty')
 
@@ -12,16 +17,17 @@ export const spawn: typeof import('node-pty').spawn = pty.spawn
  * Returns a node module installed with VSCode, or null if it fails.
  */
 function getCoreNodeModule(moduleName: string) {
+    const r = typeof WEBPACK_REQUIRE === 'function' ? NON_WEBPACK_REQUIRE : require
     try {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-        return require(`${vscode.env.appRoot}/node_modules.asar/${moduleName}`)
+        return r(`${vscode.env.appRoot}/node_modules.asar/${moduleName}`)
     } catch (err) {
         console.error(`Failed to getCoreNodeModule '${moduleName}': ${err as string}`)
     }
 
     try {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-        return require(`${vscode.env.appRoot} / node_modules / ${moduleName}`)
+        return r(`${vscode.env.appRoot}/node_modules/${moduleName}`)
     } catch (err) {
         console.error(`Failed to getCoreNodeModule '${moduleName}': ${err as string}`)
     }


### PR DESCRIPTION
```
[error] TypeError: Cannot read properties of null (reading 'spawn')
	at Object.<anonymous> (/root/.vscode-server/extensions/bilelmoussaoui.flatpak-vscode-0.0.32/out/nodePty.js:8:21)
	at Module._compile (node:internal/modules/cjs/loader:1103:14)
	at Object.Module._extensions..js (node:internal/modules/cjs/loader:1157:10)
	at Module.load (node:internal/modules/cjs/loader:981:32)
	at Function.Module._load (node:internal/modules/cjs/loader:822:12)
	at Function.c._load (/root/.vscode-server/bin/ee2b180d582a7f601fa6ecfdad8d9fd269ab1884/out/vs/workbench/api/node/extensionHostProcess.js:122:14101)
	at Function.m._load (/root/.vscode-server/bin/ee2b180d582a7f601fa6ecfdad8d9fd269ab1884/out/vs/workbench/api/node/extensionHostProcess.js:117:62404)
	at Function.C._load (/root/.vscode-server/bin/ee2b180d582a7f601fa6ecfdad8d9fd269ab1884/out/vs/workbench/api/node/extensionHostProcess.js:117:61797)
	at Module.require (node:internal/modules/cjs/loader:1005:19)
	at require (node:internal/modules/cjs/helpers:102:18)
	at Object.<anonymous> (/root/.vscode-server/extensions/bilelmoussaoui.flatpak-vscode-0.0.32/out/command.js:14:13)
	at Module._compile (node:internal/modules/cjs/loader:1103:14)
	at Object.Module._extensions..js (node:internal/modules/cjs/loader:1157:10)
	at Module.load (node:internal/modules/cjs/loader:981:32)
	at Function.Module._load (node:internal/modules/cjs/loader:822:12)
	at Function.c._load (/root/.vscode-server/bin/ee2b180d582a7f601fa6ecfdad8d9fd269ab1884/out/vs/workbench/api/node/extensionHostProcess.js:122:14101)
	at Function.m._load (/root/.vscode-server/bin/ee2b180d582a7f601fa6ecfdad8d9fd269ab1884/out/vs/workbench/api/node/extensionHostProcess.js:117:62404)
	at Function.C._load (/root/.vscode-server/bin/ee2b180d582a7f601fa6ecfdad8d9fd269ab1884/out/vs/workbench/api/node/extensionHostProcess.js:117:61797)
	at Module.require (node:internal/modules/cjs/loader:1005:19)
	at require (node:internal/modules/cjs/helpers:102:18)
	at Object.<anonymous> (/root/.vscode-server/extensions/bilelmoussaoui.flatpak-vscode-0.0.32/out/utils.js:27:19)
	at Module._compile (node:internal/modules/cjs/loader:1103:14)
	at Object.Module._extensions..js (node:internal/modules/cjs/loader:1157:10)
	at Module.load (node:internal/modules/cjs/loader:981:32)
	at Function.Module._load (node:internal/modules/cjs/loader:822:12)
	at Function.c._load (/root/.vscode-server/bin/ee2b180d582a7f601fa6ecfdad8d9fd269ab1884/out/vs/workbench/api/node/extensionHostProcess.js:122:14101)
	at Function.m._load (/root/.vscode-server/bin/ee2b180d582a7f601fa6ecfdad8d9fd269ab1884/out/vs/workbench/api/node/extensionHostProcess.js:117:62404)
	at Function.C._load (/root/.vscode-server/bin/ee2b180d582a7f601fa6ecfdad8d9fd269ab1884/out/vs/workbench/api/node/extensionHostProcess.js:117:61797)
	at Module.require (node:internal/modules/cjs/loader:1005:19)
	at require (node:internal/modules/cjs/helpers:102:18)
	at Object.<anonymous> (/root/.vscode-server/extensions/bilelmoussaoui.flatpak-vscode-0.0.32/out/extension.js:16:17)
	at Module._compile (node:internal/modules/cjs/loader:1103:14)
	at Object.Module._extensions..js (node:internal/modules/cjs/loader:1157:10)
	at Module.load (node:internal/modules/cjs/loader:981:32)
	at Function.Module._load (node:internal/modules/cjs/loader:822:12)
	at Function.c._load (/root/.vscode-server/bin/ee2b180d582a7f601fa6ecfdad8d9fd269ab1884/out/vs/workbench/api/node/extensionHostProcess.js:122:14101)
	at Function.m._load (/root/.vscode-server/bin/ee2b180d582a7f601fa6ecfdad8d9fd269ab1884/out/vs/workbench/api/node/extensionHostProcess.js:117:62404)
	at Function.C._load (/root/.vscode-server/bin/ee2b180d582a7f601fa6ecfdad8d9fd269ab1884/out/vs/workbench/api/node/extensionHostProcess.js:117:61797)
	at Module.require (node:internal/modules/cjs/loader:1005:19)
	at require (node:internal/modules/cjs/helpers:102:18)
	at Function.r [as __$__nodeRequire] (/root/.vscode-server/bin/ee2b180d582a7f601fa6ecfdad8d9fd269ab1884/out/vs/loader.js:5:101)
	at f.qb (/root/.vscode-server/bin/ee2b180d582a7f601fa6ecfdad8d9fd269ab1884/out/vs/workbench/api/node/extensionHostProcess.js:117:63668)
	at processTicksAndRejections (node:internal/process/task_queues:96:5)
	at async Promise.all (index 0)
```