### PR TITLE
Remove host filesystem build restriction

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -295,7 +295,6 @@ export class Manifest {
         }
         let buildArgs = [
             '--share=network',
-            '--nofilesystem=host',
             `--filesystem=${this.workspace}`,
             `--filesystem=${this.repoDir}`,
         ]


### PR DESCRIPTION
Fixes #217.

I have tested with the change locally, and removing this restriction solves the ssh socket access issue. The extension should not restrict the build arguments specified by the developer in the manifest.