### PR TITLE
misc: also exit spawned command as flatpak-spawn exit

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -87,7 +87,7 @@ export class Command {
     constructor(program: string, args: string[], options?: CommandOptions) {
         if (options?.forceSandbox || IS_SANDBOXED.get()) {
             this.program = 'flatpak-spawn'
-            args.unshift('--host', '--env=TERM=xterm-256color', program)
+            args.unshift('--host', '--watch-bus', '--env=TERM=xterm-256color', program)
         } else {
             this.program = program
         }

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -19,8 +19,8 @@ suite('command', () => {
     test('sandboxed', () => {
         const command = new Command('echo', ['Hello', 'world'], { forceSandbox: true })
         assert.equal(command.program, 'flatpak-spawn')
-        assert.deepStrictEqual(command.args, ['--host', '--env=TERM=xterm-256color', 'echo', 'Hello', 'world'])
-        assert.equal(command.toString(), 'flatpak-spawn --host echo Hello world')
+        assert.deepStrictEqual(command.args, ['--host', '--watch-bus', '--env=TERM=xterm-256color', 'echo', 'Hello', 'world'])
+        assert.equal(command.toString(), 'flatpak-spawn --host --watch-bus echo Hello world')
     })
 
     test('notSandboxed', () => {


### PR DESCRIPTION
This seems to fix some scenarios where r-a keeps running even with VSCode shut down, and this appears to be also done by Builder:  https://gitlab.gnome.org/GNOME/gnome-builder/-/blob/main/src/libide/foundry/ide-run-context.c#L284