### PR TITLE
fix: Only write to workspace configuration when settings need to change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [unreleased]
+- feat: set Devel manifest as default manifest if any
+- fix: Only write to workspace configuration when settings need to change
+
 ## [0.0.36]
 
 - misc: also exit spawned command as flatpak-spawn exit

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -646,7 +646,9 @@ export class Manifest {
         value?: string | string[] | boolean
     ): Promise<void> {
         const config = vscode.workspace.getConfiguration(section)
-        await config.update(configName, value)
+        if (config.get(configName) !== value) {
+            await config.update(configName, value)
+        }
     }
 
     async restoreWorkspaceConfig(


### PR DESCRIPTION
The workspace configuration in `.vscode/settings.json` is dependent on the order of `config.update()` calls. This causes a diff in my project, which is only a change in the order of the settings. By only calling `update()` when a change is needed, VSCode will not touch the `settings.json` once the configuration is correct.