### PR TITLE
manifest: Use full meson setup command

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -490,6 +490,7 @@ export class Manifest {
                         ...buildArgs,
                         this.repoDir,
                         'meson',
+                        'setup',
                         '--prefix',
                         '/app',
                         mesonBuildDir,


### PR DESCRIPTION
This fixes deprecated warnings while building.