### PR TITLE
command: add -no-pty when saving command as script

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -135,10 +135,7 @@ export class Command {
     }
 
     toString(): string {
-        return [
-            this.program,
-            ...this.args.filter((arg) => arg !== '--env=TERM=xterm-256color')
-        ].join(' ')
+        return [this.program, ...this.args].join(' ')
     }
 
     /**
@@ -146,8 +143,14 @@ export class Command {
      * @param path save location
      */
     async saveAsScript(path: PathLike): Promise<void> {
-        const cmd = ['#!/bin/sh', '', `${this.toString()} "$@"`].join('\n')
-        await fs.writeFile(path, cmd)
+        const args = this.args.filter((arg) => arg !== '--env=TERM=xterm-256color')
+        if (this.program === 'host-spawn') {
+            args.unshift('-no-pty')
+        }
+        const commandStr = [this.program, ...args].join(' ')
+
+        const fileContents = ['#!/bin/sh', '', `${commandStr} "$@"`].join('\n')
+        await fs.writeFile(path, fileContents)
         await fs.chmod(path, 0o755)
     }
 

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -20,7 +20,7 @@ suite('command', () => {
         const command = new Command('echo', ['Hello', 'world'], { forceSandbox: true })
         assert.equal(command.program, 'flatpak-spawn')
         assert.deepStrictEqual(command.args, ['--host', '--watch-bus', '--env=TERM=xterm-256color', 'echo', 'Hello', 'world'])
-        assert.equal(command.toString(), 'flatpak-spawn --host --watch-bus echo Hello world')
+        assert.equal(command.toString(), 'flatpak-spawn --host --watch-bus --env=TERM=xterm-256color echo Hello world')
     })
 
     test('notSandboxed', () => {


### PR DESCRIPTION
This fixes rust-analyzer from not starting.

As a side effect, this fix also makes the command display on `outputTerminal` more accurate by keeping the command display untouched and moving `saveAsScript` specific command modifications to itself.