### PR TITLE
manifest: Allow to configure directories to ignore while searching for manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [Unreleased]
+
+- manifest: Allow to configure directories to ignore while searching for manifests
+
 ## [0.0.37]
 
 - manifest: Automatically set `development` flatpak manifests, suffixed with `Devel` / `.devel` by default

--- a/package.json
+++ b/package.json
@@ -214,7 +214,20 @@
         ],
         "url": "https://raw.githubusercontent.com/flatpak/flatpak-builder/master/data/flatpak-manifest.schema.json"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "Flatpak",
+      "properties": {
+        "flatpak-vscode.excludeManifestDirs": {
+          "markdownDescription": "These directories, with `.flatpak` and `_build`, will be ignored when searching for Flatpak manifests. You may also need to add these folders to Code's `files.watcherExclude` for performance.",
+          "default": ["target", ".vscode", ".flatpak-builder", "flatpak_app", ".github"],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "yarn run compile",

--- a/src/manifestManager.ts
+++ b/src/manifestManager.ts
@@ -58,6 +58,12 @@ export class ManifestManager implements vscode.Disposable {
             manifests.delete(deletedUri)
         })
 
+        vscode.workspace.onDidChangeConfiguration(async (event) => {
+            if (event.affectsConfiguration('flatpak-vscode')) {
+                await this.refreshManifests()
+            }
+        })
+
         this.statusItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left)
         this.updateStatusItem()
     }
@@ -141,6 +147,14 @@ export class ManifestManager implements vscode.Disposable {
         }
 
         return this.manifests
+    }
+
+    async refreshManifests(): Promise<void> {
+        if (this.manifests !== undefined) {
+            console.log('Refreshing Flatpak manifests')
+            const newManifests = await findManifests()
+            this.manifests.update(newManifests)
+        }
     }
 
     /**

--- a/src/manifestMap.ts
+++ b/src/manifestMap.ts
@@ -41,6 +41,18 @@ export class ManifestMap implements Iterable<Manifest> {
         return isDeleted
     }
 
+    update(other: ManifestMap): void {
+        for (const manifest of this) {
+            if (!other.inner.has(manifest.uri.fsPath)) {
+                this.delete(manifest.uri)
+            }
+        }
+
+        for (const manifest of other) {
+            this.add(manifest)
+        }
+    }
+
     get(uri: vscode.Uri): Manifest | undefined {
         return this.inner.get(uri.fsPath)
     }

--- a/src/manifestMap.ts
+++ b/src/manifestMap.ts
@@ -6,6 +6,10 @@ export class ManifestMap implements Iterable<Manifest> {
 
     private readonly _onDidItemsChanged = new vscode.EventEmitter<void>()
     readonly onDidItemsChanged = this._onDidItemsChanged.event
+    private readonly _onDidItemAdded = new vscode.EventEmitter<Manifest>()
+    readonly onDidItemAdded = this._onDidItemAdded.event
+    private readonly _onDidItemDeleted = new vscode.EventEmitter<vscode.Uri>()
+    readonly onDidItemDeleted = this._onDidItemDeleted.event
 
     constructor() {
         this.inner = new Map()
@@ -16,8 +20,14 @@ export class ManifestMap implements Iterable<Manifest> {
     }
 
     add(manifest: Manifest): void {
+        const isAdded = !this.inner.has(manifest.uri.fsPath)
+
         this.inner.set(manifest.uri.fsPath, manifest)
         this._onDidItemsChanged.fire()
+
+        if (isAdded) {
+            this._onDidItemAdded.fire(manifest)
+        }
     }
 
     delete(uri: vscode.Uri): boolean {
@@ -25,6 +35,7 @@ export class ManifestMap implements Iterable<Manifest> {
 
         if (isDeleted) {
             this._onDidItemsChanged.fire()
+            this._onDidItemDeleted.fire(uri)
         }
 
         return isDeleted

--- a/src/manifestUtils.ts
+++ b/src/manifestUtils.ts
@@ -18,9 +18,14 @@ export const MANIFEST_PATH_GLOB_PATTERN = '**/*.{json,yaml,yml}'
  * @returns List of Flatpak Manifest
  */
 export async function findManifests(): Promise<ManifestMap> {
+    // Always exclude the directories we generate.
+    const excludeBaseDirs = ['.flatpak', '_build']
+    const excludeConfigDirs = workspace.getConfiguration('flatpak-vscode').get<string[]>('excludeManifestDirs')
+    const excludeDirs = excludeBaseDirs.concat(excludeConfigDirs ?? []).join(',')
+
     const uris: Uri[] = await workspace.findFiles(
         MANIFEST_PATH_GLOB_PATTERN,
-        '**/{target,.vscode,.flatpak-builder,flatpak_app,.flatpak,_build,.github}/*',
+        `**/{${excludeDirs}}/*`,
         1000
     )
     const manifests = new ManifestMap()

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -104,6 +104,45 @@ suite('manifestMap', () => {
         })
         assert.equal(nIter, 2)
     })
+
+    test('update', () => {
+        const first_map = new ManifestMap()
+        assert(first_map.isEmpty())
+
+        const second_map = new ManifestMap()
+        assert(second_map.isEmpty())
+
+        const manifestAUri = Uri.file('/home/test/a.a.a.json')
+        const manifestA = createTestManifest(manifestAUri)
+
+        const manifestBUri = Uri.file('/home/test/b.b.b.json')
+        const manifestB = createTestManifest(manifestBUri)
+
+        first_map.add(manifestA)
+        assert.equal(first_map.size(), 1)
+        assert.deepStrictEqual(first_map.get(manifestAUri), manifestA)
+
+        second_map.add(manifestB)
+        assert.equal(second_map.size(), 1)
+        assert.deepStrictEqual(second_map.get(manifestBUri), manifestB)
+
+        first_map.update(second_map)
+        assert.equal(first_map.size(), 1)
+        assert.deepStrictEqual(first_map.get(manifestBUri), manifestB)
+
+        second_map.delete(manifestBUri)
+        assert(second_map.isEmpty())
+
+        first_map.update(second_map)
+        assert(first_map.isEmpty())
+
+        second_map.add(manifestA)
+        second_map.add(manifestB)
+        assert.equal(second_map.size(), 2)
+
+        first_map.update(second_map)
+        assert.equal(first_map.size(), 2)
+    })
 })
 
 suite('manifestUtils', () => {


### PR DESCRIPTION
When using other build systems in the same directory, it is possible that the extension does not find manifests because it gets the first 1000 YAML and JSON files it encounters and none of them are manifests, resulting in the same problem as #229. A solution for that is to be able to configure which directories to ignore, so it is more likely that it will be able to get the manifests in the result.

The first commit is preparatory work for the second commit, to allow us to refresh the map of manifests when the config changes, thus avoiding to have to reload the extension to take those changes into account.

Tested locally.