### PR TITLE
runInRepo: Run with filesystem permissions to the workdir

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -597,6 +597,8 @@ export class Manifest {
             '--with-appdir',
             '--allow=devel',
             `--bind-mount=/run/user/${uid}/doc=/run/user/${uid}/doc/by-app/${appId}`,
+            `--filesystem=${this.workspace}`,
+            `--filesystem=${this.repoDir}`,
             ...this.finishArgs(),
             '--talk-name=org.freedesktop.portal.*',
             '--talk-name=org.a11y.Bus',


### PR DESCRIPTION
This never had repository permissions for some reason. You had to ensure your manifest had `--filesystem=host` or similar otherwise tools like rust-analyzer and build terminal would not actually have any access to the source code.

I have no idea if this is some sort of regression or if this never worked, but builder does the same so it should be alright:

https://gitlab.gnome.org/GNOME/gnome-builder/-/blob/main/src/plugins/flatpak/gbp-flatpak-runtime.c#L242

Also we do it here when actually running a build too:

https://github.com/bilelmoussaoui/flatpak-vscode/blob/c42b55980a7555ac68ba656eae18dd74d7c60a05/src/manifest.ts#L299